### PR TITLE
auth: Search payload on 'form' and 'data' while registering

### DIFF
--- a/auth/auth_logic.py
+++ b/auth/auth_logic.py
@@ -141,9 +141,15 @@ def register():
     """Register Form"""
     logger.info(str(request))
     try:
-        username = request.form['username']
-        password = hashlib.md5(request.form['password'].encode()).hexdigest()
-        email = request.form['email']
+        if len(request.form) != 0:
+            payload = request.form
+        elif len(request.data) != 0:
+            payload = json.loads(request.data)
+        else: raise Exception("No data received")
+
+        username = payload['username']
+        password = hashlib.md5(payload['password'].encode()).hexdigest()
+        email = payload['email']
 
         if not check_mail(email):
             return jsonify(result='Registration failed: Not valid email'), 400


### PR DESCRIPTION
Hi, I made this change when I first integrated the authentication on the Portal because I could not find an easy way to send the request with the payload in `form`. The idea is to first check if there is content in `form` and, if not, try to take the same values from `data` instead.

I just checked with the latest version and the changes are still valid.